### PR TITLE
docs: update Attendance.md with engagement log entry

### DIFF
--- a/Attendance.md
+++ b/Attendance.md
@@ -58,3 +58,4 @@ CONFIDENTIALITY LEVEL: INTERNAL // AUDIT ONLY
 | 2026-02-27 16:24:33 UTC | Code: JUN-A | red-team/log-update | Pending | Updated Red Team operational log | [INFO: SYSTEM STABLE] | 80B64DC8 |
 | 2026-02-28 16:35:18 UTC | Code: TER-AWIS | red-team/log-update | Pending | Updated Red Team operational log | [INFO: SYSTEM STABLE] | 66E67BCF |
 | 2026-03-01 16:04:56 UTC | Code: JAN-GGUT | red-team/log-update | Pending | Updated Red Team operational log | [INFO: SYSTEM STABLE] | 52563F7B |
+| 2026-03-02 16:30:59 UTC | Code: JUN-A | red-team/log-update | Pending | Updated Red Team operational log | [INFO: SYSTEM STABLE] | 0713186A |


### PR DESCRIPTION
Appended a new entry to the Red Team Engagement Log in Attendance.md with current timestamp, assigned random operative, action summary, and generated signature.

---
*PR created automatically by Jules for task [130130282162727565](https://jules.google.com/task/130130282162727565) started by @AgentHitmanFaris*