### PR TITLE
Appended audit entry to operational engagement log

### DIFF
--- a/Attendance.md
+++ b/Attendance.md
@@ -100,3 +100,4 @@ CONFIDENTIALITY LEVEL: INTERNAL // AUDIT ONLY
 | 2026-04-09 16:14:21 UTC | Code: PER-AK | red-team/log-update | Pending | Updated Red Team operational log | [INFO: SYSTEM STABLE] | 59343507 |
 | 2026-04-10 16:19:51 UTC | Code: KIL-AU | red-team/log-update | Pending | Appended audit entry to operational engagement log | [INFO: SYSTEM STABLE] | CB67C04B |
 | 2026-04-11 16:12:54 UTC | Code: BAH-AMAN | red-team/log-update | Pending | Appended audit entry to operational engagement log | [INFO: SYSTEM STABLE] | 7FE06CFE |
+| 2026-04-12 16:06:53 UTC | Code: PER-AK | red-team/log-update | Pending | Appended audit entry to operational engagement log | [INFO: SYSTEM STABLE] | 4AC0AAC4 |


### PR DESCRIPTION
Updated `Attendance.md` to append a new audit entry via the operational engagement log. Used the existing `update_log.py` script to generate a standardized row.

---
*PR created automatically by Jules for task [15257375695415567023](https://jules.google.com/task/15257375695415567023) started by @AgentHitmanFaris*